### PR TITLE
Fix plasmashell crashing with new nvidia drivers

### DIFF
--- a/gr.ictpro.jsalatas.plasma.pstate/contents/ui/ComboBox.qml
+++ b/gr.ictpro.jsalatas.plasma.pstate/contents/ui/ComboBox.qml
@@ -81,6 +81,6 @@ RowLayout {
             }
 
         }
-        Layout.minimumWidth: parent.width
+        Layout.minimumWidth: units.gridUnit * 4
     }
 }


### PR DESCRIPTION
Starting with nvidia 450, some qml arguments cause things to act funny.
The old argument used here causes plasmashell to crash with nvidia drivers. Luckily, an easy fix is found here: https://github.com/jsalatas/plasma-pstate/issues/63#issuecomment-706692728
This is the change I made.